### PR TITLE
Update Dockerfile for Fastball 0.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.6-alpine
 
 # Install necessary gems
 RUN gem install aws-sdk-secretsmanager
-RUN gem install fastball --source https://github.com/kalkomey/fastball
+RUN gem install fastball --source https://Gfgyva8mFUA6fPCfz6uV@gem.fury.io/me/ -v 0.5.0
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# 📝  Overview

Even though we specify Ruby to install Fastball from our kalkomey/fastball repository, this actually results in a 404 and it ends up pulling the gem 0.4.1 from rubygems (you can see this if you specify the verbose flag). We need to use version 0.5.0 for our PHP apps that have .erb files in the conf/ directory.